### PR TITLE
Add lazy SMILES dataset for VAE training

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,12 @@ polygon train \
 	--n_epoch 200 \
 	--n_batch 1024 \
 	--debug \
-	--d_dropout 0.2 \
-	--device cpu
+        --d_dropout 0.2 \
+        --device cpu
 ```
+
+The training command now streams SMILES directly from disk using a lazy dataset,
+which allows handling files that do not fit into RAM.
 
 Train Ligand Binding Models for Two Protein Targets
 ```

--- a/polygon/run.py
+++ b/polygon/run.py
@@ -34,6 +34,7 @@ from polygon.utils.utils import str2bool
 from polygon.utils.utils import canonicalize_list
 from polygon.utils.train_ligand_binding_model import train_ligand_binding_model
 from polygon.version import __version__
+from polygon.utils.smiles_dataset import SmilesDataset
 
 ################################################################################
 # Command line parsing
@@ -586,16 +587,14 @@ def train_main(args):
     if device.type.startswith("cuda"):
         torch.cuda.set_device(device.index or 0)
 
-    # get training data
-    with open(args.train_data, "r") as handle:
-        logging.debug("Get training data.")
-        train_data = [line.rstrip() for line in handle.readlines()]
+    # get training data lazily to avoid loading the whole file into memory
+    logging.debug("Get training data.")
+    train_data = SmilesDataset(args.train_data)
 
     if args.validation_data:
-        # get validation data
+        # get validation data lazily
         logging.debug("Get validation data.")
-        with open(args.validation_data, "r") as handle:
-            validation_data = [line.rstrip() for line in handle.readlines()]
+        validation_data = SmilesDataset(args.validation_data)
     else:
         validation_data = None
 

--- a/polygon/utils/__init__.py
+++ b/polygon/utils/__init__.py
@@ -2,3 +2,4 @@ import polygon.utils.custom_scoring_fcn
 import polygon.utils.moses_utils
 import polygon.utils.smiles_char_dict
 import polygon.utils.utils
+import polygon.utils.smiles_dataset

--- a/polygon/utils/smiles_dataset.py
+++ b/polygon/utils/smiles_dataset.py
@@ -1,0 +1,26 @@
+import os
+from torch.utils.data import Dataset
+
+class SmilesDataset(Dataset):
+    """Dataset for reading SMILES strings lazily from a file."""
+
+    def __init__(self, path: str):
+        self.path = path
+        if not os.path.isfile(self.path):
+            raise ValueError(f"File not found: {self.path}")
+        self.offsets = []
+        offset = 0
+        with open(self.path, "rb") as f:
+            for line in f:
+                self.offsets.append(offset)
+                offset = f.tell()
+
+    def __len__(self):
+        return len(self.offsets)
+
+    def __getitem__(self, idx: int):
+        with open(self.path, "rb") as f:
+            f.seek(self.offsets[idx])
+            line = f.readline().decode("utf-8")
+        return line.rstrip("\n")
+


### PR DESCRIPTION
## Summary
- create `SmilesDataset` that lazily reads SMILES from disk
- import and use `SmilesDataset` in the training routine
- document streaming behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686e78ac6474832095d039c5fdda492e