### PR TITLE
Add lazy SMILES dataset for VAE training

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,13 @@ polygon train \
 	--n_epoch 200 \
 	--n_batch 1024 \
 	--debug \
-	--d_dropout 0.2 \
-	--device cpu
+        --d_dropout 0.2 \
+        --device cpu
 ```
+
+The training command now streams SMILES directly from disk using a lazy
+`SmilesDataset`, which avoids loading the entire file into memory.  Random
+shuffling is disabled for this streaming mode to keep memory usage low.
 
 Train Ligand Binding Models for Two Protein Targets
 ```

--- a/polygon/run.py
+++ b/polygon/run.py
@@ -34,6 +34,7 @@ from polygon.utils.utils import str2bool
 from polygon.utils.utils import canonicalize_list
 from polygon.utils.train_ligand_binding_model import train_ligand_binding_model
 from polygon.version import __version__
+from polygon.utils.smiles_dataset import SmilesDataset
 
 ################################################################################
 # Command line parsing
@@ -586,16 +587,14 @@ def train_main(args):
     if device.type.startswith("cuda"):
         torch.cuda.set_device(device.index or 0)
 
-    # get training data
-    with open(args.train_data, "r") as handle:
-        logging.debug("Get training data.")
-        train_data = [line.rstrip() for line in handle.readlines()]
+    # get training data lazily to avoid loading the whole file into memory
+    logging.debug("Get training data.")
+    train_data = SmilesDataset(args.train_data)
 
     if args.validation_data:
-        # get validation data
+        # get validation data lazily
         logging.debug("Get validation data.")
-        with open(args.validation_data, "r") as handle:
-            validation_data = [line.rstrip() for line in handle.readlines()]
+        validation_data = SmilesDataset(args.validation_data)
     else:
         validation_data = None
 

--- a/polygon/utils/__init__.py
+++ b/polygon/utils/__init__.py
@@ -2,3 +2,4 @@ import polygon.utils.custom_scoring_fcn
 import polygon.utils.moses_utils
 import polygon.utils.smiles_char_dict
 import polygon.utils.utils
+import polygon.utils.smiles_dataset

--- a/polygon/utils/smiles_dataset.py
+++ b/polygon/utils/smiles_dataset.py
@@ -1,0 +1,22 @@
+import os
+from torch.utils.data import IterableDataset
+
+class SmilesDataset(IterableDataset):
+    """Iterably read SMILES strings from a text file with minimal memory."""
+
+    def __init__(self, path: str):
+        self.path = path
+        if not os.path.isfile(self.path):
+            raise ValueError(f"File not found: {self.path}")
+        # count lines once to provide __len__ without storing offsets
+        with open(self.path, "rb") as f:
+            self._length = sum(1 for _ in f)
+
+    def __iter__(self):
+        with open(self.path, "r", encoding="utf-8") as f:
+            for line in f:
+                yield line.rstrip("\n")
+
+    def __len__(self):
+        return self._length
+

--- a/polygon/vae/vae_trainer.py
+++ b/polygon/vae/vae_trainer.py
@@ -4,7 +4,7 @@ import logging
 import torch
 import torch.optim as optim
 from torch.nn.utils import clip_grad_norm_
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, IterableDataset
 #from utils.moses_utils import OneHotVocab
 from polygon.utils.moses_utils import CircularBuffer
 from polygon.utils.moses_utils import set_torch_seed_to_all_gens
@@ -87,8 +87,11 @@ class VAETrainer(ABC):
         else:
             worker_init_fn = None
 
+        if isinstance(data, IterableDataset):
+            shuffle = False
+
         loader = DataLoader(data,
-                          batch_size=self.n_batch,
+                          batch_size=batch_size,
                           shuffle=shuffle,
                           num_workers=self.n_workers,
                           collate_fn=collate_fn,


### PR DESCRIPTION
## Summary
- create `SmilesDataset` that lazily reads SMILES from disk
- import and use `SmilesDataset` in the training routine
- document streaming behaviour in README
- avoid shuffle for iterable dataset to reduce memory usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686e78ac6474832095d039c5fdda492e