### PR TITLE
Add chemprop default and BBB scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ polygon train_reward_model \
 
 Set `--dataset_type` to `classification` for classification tasks.
 
+Ligand efficiency scoring can load either a pickled random forest model or a
+trained Chemprop model.  The default backend is now Chemprop; specify
+`model: randomforest` in your scoring definition if you prefer the RF model.
+
 ## YAML Scoring Definitions
 
 Scoring definitions used during molecule generation can now be provided as YAML in addition to CSV.  A YAML file should contain a list under the key `scoring` with the same fields as the original CSV, for example:
@@ -149,7 +153,19 @@ scoring:
     minimize: false
     mu: 0.8
     sigma: 0.3
-    file: ../data/RFR_ligand_binding_model_MTOR.pkl
+    file: ../data/chemprop_model_MTOR.pth
+  - category: sa
+    name: sa
+    minimize: true
+    mu: 3.0
+    sigma: 1.0
+  - category: bbb
+    name: bbb
+    minimize: false
+    mu: 0.5
+    sigma: 0.1
 ```
 
 Use the YAML file by passing it to `--scoring_definition` when running `polygon generate`.
+
+Additional categories include `sa` for synthetic accessibility and `bbb` for blood-brain barrier predictions using ADMET-AI.

--- a/polygon/utils/utils.py
+++ b/polygon/utils/utils.py
@@ -41,6 +41,7 @@ from polygon.utils.custom_scoring_fcn import LogP
 from polygon.utils.custom_scoring_fcn import MW
 from polygon.utils.custom_scoring_fcn import TaniSim
 from polygon.utils.custom_scoring_fcn import LigandEfficancy
+from polygon.utils.custom_scoring_fcn import BBBScore
 
 
 
@@ -282,11 +283,17 @@ def build_scoring_function( scoring_definition,
                                                                             sigma=row.sigma,
                                                                             minimize=row.minimize))
         elif row.category == "sa":
-            scorers[name] = SAScorer( 
+            scorers[name] = SAScorer(
                                     score_modifier=MinMaxGaussianModifier(mu=row.mu,
                                                                             sigma=row.sigma,
                                                                             minimize=row.minimize),
-                                    fscores=fscores  
+                                    fscores=fscores
+                                    )
+        elif row.category == "bbb":
+            scorers[name] = BBBScore(
+                                    score_modifier=MinMaxGaussianModifier(mu=row.mu,
+                                                                           sigma=row.sigma,
+                                                                           minimize=row.minimize),
                                     )
         elif row.category == "latent_distance":
             if vae_model == None:
@@ -317,12 +324,14 @@ def build_scoring_function( scoring_definition,
                                                                             minimize=row.minimize),
                                     )  
         elif row.category == 'ligand_efficiency':
+            model_type = getattr(row, 'model', 'chemprop')
             scorers[name] = LigandEfficancy(
                                     score_modifier=MinMaxGaussianModifier( mu=row.mu,
                                                                             sigma=row.sigma,
                                                                             minimize=row.minimize),
-                                    model_path=row.file
-                                    )                           
+                                    model_path=row.file,
+                                    model=model_type
+                                    )
         else:
             print("WTF Did not understand category: {}".format(row.category))
  


### PR DESCRIPTION
## Summary
- default ligand efficiency scoring now uses Chemprop
- add BBBScore class using admet_ai for BBB predictions
- wire BBB scoring category in utils
- document SA and BBB examples in README

## Testing
- `python -m py_compile polygon/utils/custom_scoring_fcn.py`
- `python -m py_compile polygon/utils/utils.py`
- `pip install -e .` *(failed: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_687fb42ec7008320b0141940bd04e6fa