### PR TITLE
Fix training with numpy 2.x

### DIFF
--- a/polygon/utils/chemprop_utils.py
+++ b/polygon/utils/chemprop_utils.py
@@ -1,4 +1,12 @@
 import numpy as np
+
+if not hasattr(np, "VisibleDeprecationWarning"):
+    np.VisibleDeprecationWarning = type(
+        "VisibleDeprecationWarning",
+        (Warning,),
+        {},
+    )
+
 import torch
 from pathlib import Path
 from typing import List, Optional


### PR DESCRIPTION
## Summary
- fix chemprop utils for numpy 2 by adding a fallback `VisibleDeprecationWarning`

## Testing
- `python3 -m compileall -q polygon`

------
https://chatgpt.com/codex/tasks/task_b_687feacf47948320bfd19d7c2dd4f6f7