### PR TITLE
Default Chemprop to GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,13 @@ cd polygon
 pip install .
 ```
 
-optionally install cudatoolkit for gpu acceleration in pytorch
-for example:
+POLYGON uses GPU acceleration by default for Chemprop models. Install the
+CUDA-enabled versions of PyTorch and Chemprop. For example:
 ```
 conda install cudatoolkit=11.1 -c conda-forge
+pip install chemprop[gpu]
 ```
-or see https://pytorch.org/ for specific installation instructions.
+See <https://pytorch.org/> for platform specific installation instructions.
 
 Installation time is on the order of minutes.
 
@@ -121,7 +122,7 @@ CN(CN=C(O)c1ccco1)Nc1nccs1
 
 ## Training Reward Models with Chemprop
 
-POLYGON now supports training reward function models using [Chemprop](https://github.com/chemprop/chemprop).  Provide a two-column CSV file containing `smiles` and `affinity` headers and run:
+POLYGON now supports training reward function models using [Chemprop](https://github.com/chemprop/chemprop).  GPU device 0 will be used automatically when available. Provide a two-column CSV file containing `smiles` and `affinity` headers and run:
 
 ```
 polygon train_reward_model \

--- a/polygon/utils/chemprop_utils.py
+++ b/polygon/utils/chemprop_utils.py
@@ -54,7 +54,7 @@ def chemprop_train(
     epochs: int,
     save_path: Path,
     num_workers: int = 0,
-    use_gpu: bool = False,
+    use_gpu: bool = True,
 ) -> MoleculeModel:
     """Train a Chemprop model and save the best model to ``save_path``."""
 
@@ -71,6 +71,7 @@ def chemprop_train(
     ] + ([] if use_gpu else ["--no_cuda"])
 
     args = TrainArgs().parse_args(arg_list)
+    args.device = torch.device("cuda:0" if use_gpu and torch.cuda.is_available() else "cpu")
     args.task_names = [property_name]
     args.train_data_size = len(train_smiles)
 
@@ -120,7 +121,12 @@ def chemprop_train(
     return model
 
 
-def chemprop_load(model_path: Path, device: Optional[torch.device] = torch.device("cpu")) -> MoleculeModel:
+def chemprop_load(
+    model_path: Path,
+    device: Optional[torch.device] = torch.device(
+        "cuda:0" if torch.cuda.is_available() else "cpu"
+    ),
+) -> MoleculeModel:
     """Load a saved Chemprop model."""
     return load_checkpoint(path=str(model_path), device=device).eval()
 

--- a/polygon/utils/train_ligand_binding_model.py
+++ b/polygon/utils/train_ligand_binding_model.py
@@ -39,7 +39,7 @@ def train_ligand_binding_model(
         epochs=epochs,
         save_path=Path(output_path),
         num_workers=0,
-        use_gpu=False,
+        use_gpu=True,
     )
 
     logging.info("Model saved to %s", output_path)

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,8 @@ setup(
 	},
 	keywords='',
 	packages=find_packages(),
-  	install_requires=['pandas>=1.0.3','numpy>=1.18.1','rdkit>=2019.09.3','torch>=1.4.0','joblib>=0.14.1','scikit-learn>=0.22.1'],
-	include_package_data=True,
+        install_requires=['pandas>=1.0.3','numpy>=1.18.1','rdkit>=2019.09.3','torch>=1.4.0','joblib>=0.14.1','scikit-learn>=0.22.1','chemprop>=1.5.0'],
+        include_package_data=True,
 )
 
 


### PR DESCRIPTION
## Summary
- use GPU by default for chemprop models
- load chemprop models on `cuda:0` when available
- train ligand binding models on GPU
- document CUDA/GPU dependencies and add chemprop to install_requires

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687ff3dc5e808320904428876072fef8