### PR TITLE
Fix GPU device handling for reward model training

### DIFF
--- a/polygon/utils/chemprop_utils.py
+++ b/polygon/utils/chemprop_utils.py
@@ -82,7 +82,7 @@ def chemprop_train(
     train_loader = chemprop_build_data_loader(train_smiles, train_properties, shuffle=True, num_workers=num_workers)
     val_loader = chemprop_build_data_loader(val_smiles, val_properties, shuffle=False, num_workers=num_workers)
 
-    model = MoleculeModel(args)
+    model = MoleculeModel(args).to(args.device)
     loss_func = get_loss_func(args)
     optimizer = build_optimizer(model, args)
     scheduler = build_lr_scheduler(optimizer, args)


### PR DESCRIPTION
## Summary
- move Chemprop model to the specified device when training reward models

## Testing
- `python -m py_compile polygon/utils/chemprop_utils.py`

------
https://chatgpt.com/codex/tasks/task_b_687ffa7dcd948320a5982af75f16fd97